### PR TITLE
Update test configuration for PHPUnit 12.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
             fail-fast: true
             matrix:
                 php: [8.3, 8.4]
-                laravel: [^11, ^12]
-                scout: [^10]
+                laravel: [^11, ^12, ^13]
+                scout: [^11, ^12, ^13]
 
         name: Test PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Scout ${{ matrix.scout }}
 

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,9 @@
     ],
     "require": {
         "php": "^8.0|^8.1|^8.2",
-        "illuminate/contracts": "^9|^10",
-        "illuminate/database": "^9|^10",
-        "illuminate/support": "^9|^10",
+        "illuminate/contracts": "^9|^10|^11",
+        "illuminate/database": "^9|^10|^11",
+        "illuminate/support": "^9|^10|^11",
         "laravel/scout": "^9|^10"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "devnoiseconsulting/laravel-scout-postgres-tsvector",
+    "name": "gctc-ntgc/laravel-scout-postgres-tsvector",
     "description": "PostgreSQL Full Text Search Driver for Laravel Scout",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     ],
     "require": {
         "php": "^8.1|^8.2|^8.3|^8.4",
-        "illuminate/contracts": "^10|^11|^12",
-        "illuminate/database": "^10|^11|^12",
-        "illuminate/support": "^10|^11|^12",
-        "laravel/scout": "^10|^11|^12"
+        "illuminate/contracts": "^10|^11|^12|^13",
+        "illuminate/database": "^10|^11|^12|^13",
+        "illuminate/support": "^10|^11|^12|^13",
+        "laravel/scout": "^10|^11|^12|^13"
     },
     "require-dev": {
         "larastan/larastan": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "gctc-ntgc/laravel-scout-postgres-tsvector",
+    "name": "devnoiseconsulting/laravel-scout-postgres-tsvector",
     "description": "PostgreSQL Full Text Search Driver for Laravel Scout",
     "keywords": [
         "laravel",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticProperties="false" colors="true" failOnNotice="true" failOnWarning="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd">
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticProperties="false" colors="true" failOnNotice="true" failOnWarning="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.1/phpunit.xsd">
     <coverage>
         <include>
             <directory suffix=".php">src/</directory>

--- a/src/PostgresEngine.php
+++ b/src/PostgresEngine.php
@@ -371,10 +371,10 @@ class PostgresEngine extends Engine
         }
 
         // Apply where clauses that were set on the builder instance if any
-        foreach ($builder->wheres as $key => $value) {
-            if ($key == '__soft_deleted') {
+        foreach ($builder->wheres as $where) {
+            if ($where['field'] == '__soft_deleted') {
                 if ($this->usesSoftDeletes($builder->model)) {
-                    if ($value == 1) {
+                    if ($where['value'] == 1) {
                         $query->whereNotNull($builder->model->getDeletedAtColumn());
                     } else {
                         $query->whereNull($builder->model->getDeletedAtColumn());
@@ -383,7 +383,7 @@ class PostgresEngine extends Engine
 
                 continue;
             }
-            $query->where($key, $value);
+            $query->where($where['field'], $where['operator'], $where['value']);
         }
 
         // Apply whereIn clauses that were set on the builder instance if any

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -125,8 +125,8 @@ class PostgresEngineTest extends TestCase
 
         $table->shouldReceive('skip')->with($skip)->andReturnSelf()
             ->shouldReceive('limit')->with($limit)->andReturnSelf()
-            ->shouldReceive('where')->with('bar', 1)->andReturnSelf()
-            ->shouldReceive('where')->with('baz', 'qux')
+            ->shouldReceive('where')->with('bar', '=', 1)->andReturnSelf()
+            ->shouldReceive('where')->with('baz', '=', 'qux')
             ->shouldReceive('getBindings')->andReturn([null, 'foo', 1, 'qux']);
 
         $db->shouldReceive('select')
@@ -174,8 +174,8 @@ class PostgresEngineTest extends TestCase
 
         $table->shouldReceive('skip')->with($skip)->andReturnSelf()
             ->shouldReceive('limit')->with($limit)->andReturnSelf()
-            ->shouldReceive('where')->with('bar', 1)->andReturnSelf()
-            ->shouldReceive('where')->with('baz', 'qux')
+            ->shouldReceive('where')->with('bar', '=', 1)->andReturnSelf()
+            ->shouldReceive('where')->with('baz', '=', 'qux')
             ->shouldReceive('getBindings')->andReturn([null, 'foo', 1, 'qux']);
 
         $db->shouldReceive('select')
@@ -247,7 +247,7 @@ class PostgresEngineTest extends TestCase
 
         $table->shouldReceive('skip')->with($skip)->andReturnSelf()
             ->shouldReceive('limit')->with($limit)->andReturnSelf()
-            ->shouldReceive('where')->with('bar', 1)
+            ->shouldReceive('where')->with('bar', '=', 1)
             ->shouldReceive('getBindings')->andReturn(['simple', 'foo', 1]);
 
         $db->shouldReceive('select')->with(null, $table->getBindings())->once();
@@ -269,7 +269,7 @@ class PostgresEngineTest extends TestCase
 
         $table->shouldReceive('skip')->with($skip)->andReturnSelf()
             ->shouldReceive('limit')->with($limit)->andReturnSelf()
-            ->shouldReceive('where')->with('bar', 1)
+            ->shouldReceive('where')->with('bar', '=', 1)
             ->shouldReceive('getBindings')->andReturn(['english', 'foo', 1]);
 
         $db->shouldReceive('select')->with(null, $table->getBindings())->once();
@@ -292,7 +292,7 @@ class PostgresEngineTest extends TestCase
 
         $table->shouldReceive('skip')->with(0)->andReturnSelf()
             ->shouldReceive('limit')->with(5)->andReturnSelf()
-            ->shouldReceive('where')->with('bar', 1)->andReturnSelf()
+            ->shouldReceive('where')->with('bar', '=', 1)->andReturnSelf()
             ->shouldReceive('whereNull')->with('deleted_at')
             ->shouldReceive('getBindings')->andReturn([null, 'foo', 1]);
 

--- a/tests/PostgresEngineTest.php
+++ b/tests/PostgresEngineTest.php
@@ -11,12 +11,11 @@ use Illuminate\Database\PostgresConnection;
 use Laravel\Scout\Builder;
 use Mockery;
 use ScoutEngines\Postgres\PostgresEngine;
+use PHPUnit\Framework\Attributes\Test;
 
 class PostgresEngineTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_can_be_instantiated()
     {
         [$engine] = $this->getEngine();
@@ -24,9 +23,7 @@ class PostgresEngineTest extends TestCase
         $this->assertInstanceOf(PostgresEngine::class, $engine);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function update_adds_object_to_index()
     {
         [$engine, $db] = $this->getEngine();
@@ -55,9 +52,7 @@ class PostgresEngineTest extends TestCase
         $engine->update(Collection::make([new TestModel]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function update_do_nothing_if_index_maintenance_turned_off_globally()
     {
         [$engine] = $this->getEngine(['maintain_index' => false]);
@@ -65,9 +60,7 @@ class PostgresEngineTest extends TestCase
         $this->assertNull($engine->update(Collection::make([new TestModel])));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delete_removes_object_from_index()
     {
         [$engine, $db] = $this->getEngine();
@@ -86,9 +79,7 @@ class PostgresEngineTest extends TestCase
         $engine->delete(Collection::make([new TestModel]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delete_do_nothing_if_index_maintenance_turned_off_globally()
     {
         [$engine, $db] = $this->getEngine(['maintain_index' => false]);
@@ -98,9 +89,7 @@ class PostgresEngineTest extends TestCase
         $engine->delete(Collection::make([new TestModel]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flush_removes_all_objects_from_index()
     {
         [$engine, $db] = $this->getEngine();
@@ -115,9 +104,7 @@ class PostgresEngineTest extends TestCase
         $engine->flush(new TestModel);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function flush_does_nothing_if_index_maintenance_turned_off_globally()
     {
         [$engine, $db] = $this->getEngine(['maintain_index' => false]);
@@ -127,9 +114,7 @@ class PostgresEngineTest extends TestCase
         $engine->flush(new TestModel);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search()
     {
         [$engine, $db] = $this->getEngine();
@@ -156,9 +141,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_order_by()
     {
         [$engine, $db] = $this->getEngine();
@@ -180,9 +163,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_queryCallback()
     {
         [$engine, $db] = $this->getEngine();
@@ -211,9 +192,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_whereIn()
     {
         [$engine, $db] = $this->getEngine();
@@ -235,9 +214,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_whereNotIn()
     {
         [$engine, $db] = $this->getEngine();
@@ -259,9 +236,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_global_config()
     {
         [$engine, $db] = $this->getEngine(['config' => 'simple']);
@@ -283,9 +258,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_model_config()
     {
         [$engine, $db] = $this->getEngine(['config' => 'simple']);
@@ -310,9 +283,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function search_with_soft_deletes()
     {
         [$engine, $db] = $this->getEngine();
@@ -333,9 +304,7 @@ class PostgresEngineTest extends TestCase
         $engine->search($builder);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function maps_results_to_models()
     {
         [$engine] = $this->getEngine();
@@ -354,9 +323,7 @@ class PostgresEngineTest extends TestCase
         $this->assertCount(1, $results);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function map_filters_out_no_longer_existing_models()
     {
         [$engine] = $this->getEngine();
@@ -380,9 +347,7 @@ class PostgresEngineTest extends TestCase
         $this->assertEquals(2, $models->first()->id);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_returns_total_count()
     {
         [$engine] = $this->getEngine();
@@ -394,9 +359,7 @@ class PostgresEngineTest extends TestCase
         $this->assertEquals(100, $count);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function map_ids_returns_right_key()
     {
         [$engine, $db] = $this->getEngine();
@@ -415,9 +378,7 @@ class PostgresEngineTest extends TestCase
         $this->assertEquals([1, 2], $ids->all());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function create_index()
     {
         [$engine, $db] = $this->getEngine();
@@ -428,9 +389,7 @@ class PostgresEngineTest extends TestCase
         $engine->createIndex('bad_index');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function delete_index()
     {
         [$engine, $db] = $this->getEngine();


### PR DESCRIPTION
Updates the configuration for PHPUnit to handle the changes and deprecations for the bump to 12.1.

https://docs.phpunit.de/en/12.1/configuration.html#the-phpunit-element
https://docs.phpunit.de/en/12.1/configuration.html#the-source-element

Also updates the test cases to use the newer "test" attribute

https://docs.phpunit.de/en/12.1/attributes.html#test